### PR TITLE
Drop privileges in container image so it can run securely on Kubernetes

### DIFF
--- a/fah-gpu/Dockerfile
+++ b/fah-gpu/Dockerfile
@@ -4,6 +4,9 @@
 FROM nvidia/cuda:9.2-base-ubuntu18.04
 LABEL description="Official Folding@home GPU Container"
 
+RUN groupadd -g 9999 fahuser && \
+    useradd -r -d /fah -u 9999 -g fahuser fahuser 
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ocl-icd-opencl-dev \
@@ -24,12 +27,16 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends fah.deb \
     && rm -rf fah.deb \
     && apt-get purge --autoremove -y curl \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
+    && mkdir -p /fah \
+    && chown fahuser:fahuser /fah \
+    && chmod 750 /fah
 
 COPY README.md /
 
 WORKDIR "/fah"
-VOLUME ["/fah"]
 EXPOSE 7396 36330
+
+USER fahuser
 
 ENTRYPOINT ["/usr/bin/FAHClient", "--chdir", "/fah"]


### PR DESCRIPTION
Compute clusters have the tendency of sharing resources with mixed workloads where Folding at Home could be one of them.

To guarantee high(er) integrity of the compute clusters security and mainly integrity of the data, workload (containers) should not run in privileged mode.

In the case of Kubernetes this means that upfront inside the [resource](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) specification it needs to be known under which UID and GID the process will run.

The `VOLUME` statement inside the container could be omitted if attached during runtime of the `docker` command instead of defining this in the `Dockerfile` to make the image portable (across schedulers).

Dropping privileges can also be done by creating an `entrypoint.sh` wrapper script, but that makes the solution less elegant and also rules out Kubernetes support with a (stricter) `securityContext` set since the container starts as `root`, but later on drops it out of Kubernetes-es line of sight.