### PR TITLE
feat: bump ROCm to 3.10.0 and be explicit about which ROCm ver to use

### DIFF
--- a/fah-gpu-amd/Dockerfile
+++ b/fah-gpu-amd/Dockerfile
@@ -3,6 +3,8 @@
 FROM ubuntu:18.04
 LABEL description="Folding@home AMD ROCm Container"
 
+ARG ROCM_VER=3.10.0
+
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       curl \
@@ -13,7 +15,7 @@ RUN apt-get update \
     && curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
     && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
     && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends \
-      rocm-dev \
+      rocm-dev${ROCM_VER} \
     # next line gets past the fahclient.postinst
     && mkdir -p /etc/fahclient && touch /etc/fahclient/config.xml \
     # download and verify checksum
@@ -29,7 +31,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # explicitly point FAHClient to the ROCm libOpenCL
-ENV LD_LIBRARY_PATH=/opt/rocm-3.9.0/opencl/lib/x86_64
+ENV LD_LIBRARY_PATH=/opt/rocm-${ROCM_VER}/lib
 
 WORKDIR "/fah"
 VOLUME ["/fah"]

--- a/fah-gpu-amd/README.md
+++ b/fah-gpu-amd/README.md
@@ -34,6 +34,8 @@ for clarity. RFC 2119 meanings.
 * MUST run the container as a uid:gid, specified with with `--user` or
   equivalent, so that the running container has read-write permissions to
   the persistent storage mounted in `/fah`.
+* MUST run the container as a user who is a member of the 'video' group and,
+  if present, the 'render' group.
 * SHOULD NOT run containers as root.
 * SHOULD NOT expose ports to internet without firewall rules, encryption, and
   strong passwords.
@@ -74,6 +76,17 @@ These values will be used in your config.xml later.
 #### For AMD GPUs
 * Host should have ROCm DKMS drivers installed per the ROCm QuickStart Guide
   <https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html>
+* Depending on your host OS (e.g. Ubuntu 20.04) you may need to add the 'render'
+ group id to the 'docker run' command:
+```bash
+dockuser@host$ getent group render
+render:x:1001:dockuser
+dockuser@host$ docker run -it --device=/dev/kfd --device=/dev/dri \
+    --security-opt seccomp=unconfined
+    --group-add video --group-add 1001 \
+    --name fah0 -d --user "$(id -u):$(id -g)" \
+    --volume $HOME/fah:/fah fah-gpu-amd
+```
 
 ## Running on a Single machine
 


### PR DESCRIPTION
Here's a bump to the latest ROCm version (3.10.0) and a better way of handling the version of ROCm to be built/used.
see also Issue #3 