### PR TITLE
change CUDA version to 11.2.2

### DIFF
--- a/fah-gpu/Dockerfile
+++ b/fah-gpu/Dockerfile
@@ -1,7 +1,7 @@
 # Folding@home GPU Container
 
-# CUDA 9.2 is chosen to be compatable with all drivers v396+
-FROM nvidia/cuda:9.2-base-ubuntu18.04
+# CUDA 11.2 is chosen to be compatable with all drivers v460+
+FROM nvidia/cuda:11.2.2-base-ubuntu18.04
 LABEL description="Official Folding@home GPU Container"
 
 RUN apt-get update \


### PR DESCRIPTION
Change base image from nvidia/cuda:9.2-base-ubuntu18.04 to nvidia/cuda:11.2.2-base-ubuntu18.04 to resolve issue #20 .
I tested this image on Ubuntu 20.04 + docker 20.10.8 on GeForce RTX 3070 and it works well.

Please let me know if there is better way to update.