### PR TITLE
Reduce fah-gpu-amd image size

### DIFF
--- a/fah-gpu-amd/Dockerfile
+++ b/fah-gpu-amd/Dockerfile
@@ -3,19 +3,24 @@
 FROM ubuntu:18.04
 LABEL description="Folding@home AMD ROCm Container"
 
-ARG ROCM_VER=4.0.0
+ARG ROCM_VER=4.3.1
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends \
+      kmod \
+      python3 \
       curl \
-      libnuma-dev \
       gnupg \
       ca-certificates \
     # get ROCm OpenCL runtime packages
     && curl -sL http://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
-    && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --install-recommends \
-      rocm-dev${ROCM_VER} \
+    && printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/${ROCM_VER}/ xenial main" | tee /etc/apt/sources.list.d/rocm.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+      rocm-opencl \
+      rocm-smi-lib \
+      rocminfo \
+      rocm-bandwidth-test \
     # next line gets past the fahclient.postinst
     && mkdir -p /etc/fahclient && touch /etc/fahclient/config.xml \
     # download and verify checksum
@@ -25,7 +30,7 @@ RUN apt-get update \
     && echo "2827f05f1c311ee6c7eca294e4ffb856c81957e8f5bfc3113a0ed27bb463b094 fah.deb" \
       | sha256sum -c --strict - \
     # install and cleanup
-    && DEBIAN_FRONTEND=noninteractive dpkg --install --force-depends fah.deb \
+    && dpkg --install --force-depends fah.deb \
     && rm -rf fah.deb \
     && apt-get purge --autoremove -y curl \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*

--- a/fah-gpu-amd/Dockerfile
+++ b/fah-gpu-amd/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update \
       rocm-opencl \
       rocm-smi-lib \
       rocminfo \
-      rocm-bandwidth-test \
     # next line gets past the fahclient.postinst
     && mkdir -p /etc/fahclient && touch /etc/fahclient/config.xml \
     # download and verify checksum
@@ -37,6 +36,7 @@ RUN apt-get update \
 
 # explicitly point FAHClient to the ROCm libOpenCL
 ENV LD_LIBRARY_PATH=/opt/rocm-${ROCM_VER}/lib
+ENV PATH=$PATH:/opt/rocm-${ROCM_VER}/bin:/opt/rocm-${ROCM_VER}/opencl/bin
 
 WORKDIR "/fah"
 VOLUME ["/fah"]

--- a/fah-gpu-amd/README.md
+++ b/fah-gpu-amd/README.md
@@ -82,7 +82,7 @@ These values will be used in your config.xml later.
 dockuser@host$ getent group render
 render:x:1001:dockuser
 dockuser@host$ docker run -it --device=/dev/kfd --device=/dev/dri \
-    --security-opt seccomp=unconfined
+    --security-opt seccomp=unconfined \
     --group-add video --group-add 1001 \
     --name fah0 -d --user "$(id -u):$(id -g)" \
     --volume $HOME/fah:/fah fah-gpu-amd
@@ -154,7 +154,7 @@ simple as possible:
 * The container orchestration needs to be able to allocate and manage GPUs.
 * Run one container per machine/VM - each client can manage many GPUs and
   CPU cores, and should have a config.xml tuned for the host/VM size.
-* Each running container must have it's own seperate persistent storage
+* Each running container must have it's own separate persistent storage
   directory mounted into the `/fah` directory of the container. They should
   be reused, but two containers should never be using the same directory.
 
@@ -188,7 +188,7 @@ Your container orchestrator should have commands equivalent to
 `docker logs ...` and `docker exec ... ` to perform the same functions.
 
 ```bash
-# See how many Work Untis have been returned by all clients
+# See how many Work Units have been returned by all clients
 grep points .../root-dir/*/log.txt .../root-dir/*/logs/*.txt
 ```
 
@@ -198,7 +198,7 @@ How containers are stopped on the cluster will effect how many Work Units are
 late or lost.
 
 ```bash
-# prefered shutdown
+# preferred shutdown
 <command> exec <container> FAHClient --send-command finish
 
 # Stop container after checkpoint, usually under 30 seconds.


### PR DESCRIPTION
- Install only OpenCL runtime and administrative commands instead of rocm-dev
  - rocm-opencl: you can check OpenCL status by running `clinfo`
  - rocminfo and kmod to run `rocminfo`
  - rocm-smi-lib, python3 to run `rocm-smi`
- Fix apt path to follow the apt path rule of ROCm repository
- Fix typos in README.md
- Increase the ROCm version number to latest (4.3.1)