### PR TITLE
Change base image and add a package to run FahCore_23

### DIFF
--- a/fah-gpu/Dockerfile
+++ b/fah-gpu/Dockerfile
@@ -1,13 +1,14 @@
 # Folding@home GPU Container
 
-# CUDA 11.2.2 is chosen to be compatible with OpenMM and drivers v460.32.03+
-FROM nvidia/cuda:11.2.2-base-ubuntu18.04
+# Ubuntu 22.04 and CUDA 11.7.1 are chosen to be compatible with OpenCL 3.0.
+FROM nvidia/cuda:11.7.1-base-ubuntu22.04
 LABEL description="Official Folding@home GPU Container"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
       ocl-icd-opencl-dev \
       clinfo \
+      libexpat1 \
       curl \
     # point at lib mapped in by container runtime
     && mkdir -p /etc/OpenCL/vendors \

--- a/fah-gpu/Dockerfile
+++ b/fah-gpu/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     && mkdir -p /etc/fahclient && touch /etc/fahclient/config.xml \
     # download and verify checksum
     && curl -fsSL \
-      https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v7.6/fahclient_7.6.21_amd64.deb \
+      https://download.foldingathome.org/releases/v7/public/fahclient/debian-stable-64bit/release/fahclient_7.6.21_amd64.deb \
       -o fah.deb \
     && echo "2827f05f1c311ee6c7eca294e4ffb856c81957e8f5bfc3113a0ed27bb463b094 fah.deb" \
       | sha256sum -c --strict - \

--- a/fah-gpu/Dockerfile
+++ b/fah-gpu/Dockerfile
@@ -1,7 +1,7 @@
 # Folding@home GPU Container
 
-# Ubuntu 22.04 and CUDA 11.7.1 are chosen to be compatible with OpenCL 3.0.
-FROM nvidia/cuda:11.7.1-base-ubuntu22.04
+# CUDA 11.2.2 is chosen to be compatible with OpenMM and drivers v460.32.03+
+FROM nvidia/cuda:11.2.2-base-ubuntu18.04
 LABEL description="Official Folding@home GPU Container"
 
 RUN apt-get update \


### PR DESCRIPTION
Since FahCore 23 (and OpenMM 8.0.3) requires OpenCL 3.0, we need to upgrade CUDA and Ubuntu versions.
- Ubuntu: 18.04 -> 22.04 (OpenCL 3.0 is supported since Ubuntu 22.04)
- CUDA:  11.2.2 -> 11.7.1 (Official CUDA image version that supports Ubuntu 22.04 is 11.7.1)

FahCore 23 requires libexpat1 shared library. So, install libexpat1 package.

This PR resolves Issue #31 .
